### PR TITLE
Adjusting the links to the broken Github repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ sudo python3 LPC_USB.py
 
 7. Verify the buffer overflow by checking the request and response from the USB traces, as documented by Figure 2; Figure 3 shows, instead, the USB analyser trace. The USB response would be 4KB.
 
-![Figure 2](https://github.com/Xen1thLabs-AE/CVE-2021-40154/blob/main/wireshark.png)
+![Figure 2](https://github.com/travisgoodspeed/CVE-2021-40154/blob/main/wireshark.png)
 
-![Figure 3](https://github.com/Xen1thLabs-AE/CVE-2021-40154/blob/main/usb_trace.png)
+![Figure 3](https://github.com/travisgoodspeed/CVE-2021-40154/blob/main/usb_trace.png)
 
 __Note 1:__ The buffer over read of 4KB can be requested in Ubuntu system due to the restriction of Libusb “MAX_CTRL_BUFFER_LENGTH”. This can be modified in a Raspberry-pi system and 16KB can be requested. Attached firmware “LPC.bin” retrieved from the LPC55s69-EVK board using a raspberry-pi 4 model b. 
 


### PR DESCRIPTION
The screenshots broke as the original Xenith Labs repo was taken down.  This PR changes two lines to repair those images in the README file, making no other changes.